### PR TITLE
feat: use regex directly for matching device node name and i2c bus addr in vi_camera_interpreter

### DIFF
--- a/include/uevent_diagnostics_publisher/interpreters/vi_camera_interpreter.hpp
+++ b/include/uevent_diagnostics_publisher/interpreters/vi_camera_interpreter.hpp
@@ -36,7 +36,7 @@ public:
   void interpret(const UeventDataType & event) override;
 
   static std::optional<std::string> searchDeviceNodeFromI2cBusAddr(
-    const std::string & search_path, const std::string & i2c_dev_addr);
+    const std::string & search_path, const std::string & i2c_dev_addr_regex);
 
 protected:
   std::optional<std::string> device_node_;

--- a/test/test_interpreter.cpp
+++ b/test/test_interpreter.cpp
@@ -10,13 +10,14 @@ TEST(InterpreterBaseTest, RegexTest)
 {
   auto interpreter_map = uevent_diagnostics_publisher::InterpreterMap();
   auto vi_camera_interpreter = interpreter_map.getInterPreter("vi_camera");
-  vi_camera_interpreter->setup(
-    ".*/tegra-capture-vi",  // dev_path
-    "CAUSE1",               // identifier_key
-    ".* 12-001c",           // key_regex
-    "camera0",              // hardware_id
-    "FUSA_HW_FAULT",        // value_key
-    "bool");                // value_type
+  vi_camera_interpreter
+    ->InterpreterBase::setup(  // call base class setup to bypass platform specific behavior
+      ".*/tegra-capture-vi",   // dev_path
+      "CAUSE1",                // identifier_key
+      ".* 12-001c",            // key_regex
+      "camera0",               // hardware_id
+      "FUSA_HW_FAULT",         // value_key
+      "bool");                 // value_type
 
   std::map<std::string, std::string> dummy_uevent;
   dummy_uevent["ACTION"] = "change";
@@ -57,18 +58,19 @@ TEST(ViCameraInterpreterTest, SearchVideoDeviceTest)
 
   auto interpreter_map = uevent_diagnostics_publisher::InterpreterMap();
   auto vi_camera_interpreter = interpreter_map.getInterPreter("vi_camera");
-  vi_camera_interpreter->setup(
-    ".*/tegra-capture-vi",  // dev_path
-    "CAUSE1",               // identifier_key
-    ".* 12-001c",           // key_regex
-    "camera0",              // hardware_id
-    "FUSA_HW_FAULT",        // value_key
-    "bool");                // value_type
+  vi_camera_interpreter
+    ->InterpreterBase::setup(  // call base class setup to bypass platform specific behavior
+      ".*/tegra-capture-vi",   // dev_path
+      "CAUSE1",                // identifier_key
+      ".* 12-001c",            // key_regex
+      "camera0",               // hardware_id
+      "FUSA_HW_FAULT",         // value_key
+      "bool");                 // value_type
   auto interpreter =
     static_cast<uevent_diagnostics_publisher::ViCameraInterpreter *>(vi_camera_interpreter.get());
 
   EXPECT_EQ(
-    interpreter->searchDeviceNodeFromI2cBusAddr(V4L2_FILE_SEARCH_PATH, "12-001c"), "video0");
+    interpreter->searchDeviceNodeFromI2cBusAddr(V4L2_FILE_SEARCH_PATH, ".* 12-001[a-z]"), "video0");
 }
 
 int main(int argc, char * argv[])


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Improvement

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->
N/A

## Description

<!-- Describe what this PR changes. -->
This PR modifies `vi_camera_interpreter` so that the regex of i2c bus passed via the configuration is also used to find the corresponding device node.

## Review Procedure

<!-- Explain how to review this PR. -->
I also updated the test file to use a regular expression for testing the above mathing function.
 
```shell
colcon test --event-handlers console_direct+
colcon test-result --all --verbose
```

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
